### PR TITLE
Handle empty proposition in Deliberate view

### DIFF
--- a/ame_client_project/ame_client_app/tests.py
+++ b/ame_client_project/ame_client_app/tests.py
@@ -1,3 +1,18 @@
-from django.test import TestCase
+from django.test import TestCase, RequestFactory
+from . import views
 
-# Create your tests here.
+
+class DeliberateTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_empty_proposition_list_returns_error(self):
+        """Deliberate should return an error when no propositions exist."""
+        views.propositions = {"proposition": []}
+        request = self.factory.get('/deliberate', {'case': '1'})
+        response = views.Deliberate(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+            "decision": ["ERROR -- Last proposition must be System 2 and Level 1 or Level 2."],
+            "judgments": [[]]
+        })

--- a/ame_client_project/ame_client_app/views.py
+++ b/ame_client_project/ame_client_app/views.py
@@ -131,7 +131,7 @@ def Deliberate(request):
     global propositions
     
     # don't call the ame unless the most recent proposition (main idea) is System 2!
-    if propositions["proposition"][0]["system"] == '2':
+    if len(propositions["proposition"]) > 0 and propositions["proposition"][0]["system"] == '2':
         pass
     else:
         # The ame should reject these but this will suffice


### PR DESCRIPTION
## Summary
- avoid indexing errors in `Deliberate` by checking list length
- add regression test for empty proposition list

## Testing
- `python ame_client_project/manage.py test --verbosity 2` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_6842045a62c0832cb02ab45f4eafed5c